### PR TITLE
Only run docker and push on push event

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,7 +20,7 @@ jobs:
         run: mvn test
   docker:
     needs: integrate
-    if: ${{ github.event.pull_request.merged }}
+    if: ${{ github.event_name == 'push' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
Right now 2 jobs are running on a merge:

1. GitHub PR Merge (pushes change)
2. Push to master (just runs CI)

After this change:

1. GitHub PRs will just do CI
2. Push to master will push change